### PR TITLE
Add game jam section with Riderquest and The Storm Always Comes

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,31 @@
                         </div>
                     </div>
                 </div>
+                <br>
+                <h3>Jam Games</h3>
+                <br>
+                <p>Sometimes I participate in game jams! Here are some of the results:</p>
+                <br>
+                <div class="project">
+                    <div class="header">
+                        <div class="title">Riderquest</div>
+                        <div class="metadata"><div class="item">Ludum Dare 41</div></div>
+                    </div>
+                    <div class="text">
+                        <p>Made in 48h. Theme: "Combine 2 Incompatible Genres" — so we did a Racing + JRPG meme.</p>
+                    </div>
+                    <a class="link" href="/riderquest/">Play it here</a>
+                </div>
+                <div class="project">
+                    <div class="header">
+                        <div class="title">The Storm Always Comes</div>
+                        <div class="metadata"><div class="item">Pirate Jam 2025</div></div>
+                    </div>
+                    <div class="text">
+                        <p>Made in a couple of days with <a href="https://pureishatsu.itch.io/" target="_blank">Pureishatsu</a>. We picked Pirate Jam 2025 (the biggest around) as an excuse to practice 3D. Theme: "You Are The Weapon": you're a war machine managing humanity's last survivors before the storm.</p>
+                    </div>
+                    <a class="link" href="https://fairfruit.itch.io/the-storm-always-comes" target="_blank">Play it on itch.io</a>
+                </div>
             </section>
 
             <section data-content="projects" class="content">


### PR DESCRIPTION
## Summary
Added a new "Jam Games" section to the games portfolio page showcasing game jam entries.

## Changes
- Added a new "Jam Games" section header with introductory text explaining participation in game jams
- Added two game jam project entries:
  - **Riderquest**: Ludum Dare 41 entry (48-hour jam combining Racing + JRPG genres)
  - **The Storm Always Comes**: Pirate Jam 2025 entry (narrative-driven resource management game about managing human survivors)
- Each project includes title, jam event metadata, description, and a playable link
- Maintained consistent styling with existing project cards on the page

## Implementation Details
- Used the existing `.project` component structure for consistency with other game entries
- Included both internal links (Riderquest) and external itch.io links (The Storm Always Comes)
- Added collaborator credit link for Pureishatsu on The Storm Always Comes project

https://claude.ai/code/session_01JbThiQJ89z6J85znMV3DGY