### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -1,0 +1,49 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+
+    - name: Install dependencies
+      run: bun install --frozen-lockfile
+
+    - name: Build
+      run: bun run build
+
+    - name: Upload Pages artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: ./build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to automatically build and deploy the project to GitHub Pages on every push to the main branch.

## Key Changes
- Added `.github/workflows/deploy-to-github-pages.yml` workflow file that:
  - Triggers on pushes to the `main` branch
  - Builds the project using Bun (`bun run build`)
  - Uploads the `./build` directory as a GitHub Pages artifact
  - Deploys the artifact to GitHub Pages
  - Uses appropriate permissions for pages deployment and artifact handling
  - Implements concurrency controls to prevent simultaneous deployments

## Implementation Details
- The workflow uses a two-job approach: `build` (compiles the project) and `deploy` (publishes to GitHub Pages)
- Bun is used as the runtime/package manager with frozen lockfile for reproducible builds
- The deployment job depends on successful completion of the build job
- GitHub Pages environment is configured with automatic URL output for deployment tracking

https://claude.ai/code/session_01JQbB767XcHqEtfVoXMgSkU